### PR TITLE
Revert the non-link-change to the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,11 +25,8 @@ Self checklist
 
 ## Changelist
 
-The link on line 23 "My changes follow the [style guide]"... it's broken, I found this one and I believe this match with the previous one.
-the previous link is the syllabus url which show "the url you are trying to connect is not safe"
+Briefly explain your PR.
 
 ## Questions
 
 Ask any questions you have for your reviewer.
-
-


### PR DESCRIPTION
https://github.com/CodeYourFuture/Module-User-Focused-Data/pull/292 accidentally updated both the link (as intended), and the default change message (which only applies to that change).